### PR TITLE
fix: 12 fastapi server fails to initialize on startup

### DIFF
--- a/src/fastapi_exp/conf/fastapi_exp.cnf.example
+++ b/src/fastapi_exp/conf/fastapi_exp.cnf.example
@@ -7,7 +7,7 @@
 # Add the authenticated and authorized user for the database connection
 DATABASE_AUTH_USER=database_user
 DATABASE_AUTH_PASSWD=password123
-DATABASE_PORT=database_server_port
+DATABASE_PORT=5432
 DATABASE_SERVER=database_server
 DATABASE=database_name
 # Debug should be a boolean value, for example, True or False


### PR DESCRIPTION
This example project should be as easy as possible for a person new to Python or FastAPI to run.  The .env-like example file contains one value with an incompatible type, the DATABASE_SERVER value, which results in an error on server start.  The value is set to be an integer.

We changed the value from a string to the default PostgreSQL port number, 5432.

This enables one to run the FastAPI server with the least effort possible, requiring no database to get started running the server and sampling the mimimal functionality availble using the docs and redoc ui.