### PR TITLE
docs 29: Add Shutdown Instructions to Readme Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,59 @@ At a minimum, one can test the FastAPI installation by executing the Hello World
 
 Instructions for running the client integration in webMethods are located in the webMethods readme [Usage](./z_non-python_resources/webmethods/about_webMethods.md#usage-testing-and-running-the-client-integration-in-integration-server) section. We realize that some people may be interested only in the FastAPI example, or the FastAPI-PostgreSQL combination. After installing and configuring the webMethods integration server and importing the Gne_HR_Sample.zip [package](./z_non-python_resources/webmethods) included in the webMethods directory of the project repository, one can execute the webMethods service that calls FastAPI and creates an export file.
 
+### Shutting Everything Down
+
+Other readmes provide instructions on installing, configuring, and starting the PostgreSQL database and client webMethods applications. This section provides a summary for shutting everything down, starting with FastAPI.
+
+#### FastAPI Shutdown
+
+As described earlier, since we did not set up FastAPI as a running process outside the terminal application, executing control-c in the server terminal session ends the process.
+
+#### Database Shutdown
+
+Absent any easier ways to shut down PostgreSQL, like using a Windows Task Manager service control or Linux service command, the following should shut down the database server successfully:
+
+```bash
+$ cd /<postgresql_installation_directory>
+# stop the server using pg_ctl
+$ /<postgresql_installation_directory>/bin/pg_ctl -D <data_directory> stop -m (fast | smart)
+# for example
+$ /Applications/Postgres.app/Contents/Versions/latest/bin/pg_ctl -D /Users/rrdoue/Library/ApplicationSupport/Postgres/var-14 stop -m fast
+# check the server log file for further information
+$ cd <data_directory>/log(s)
+# look for a line in the file below like '<date_and_time> [pid] LOG:  database system was shut down at <date_and_time>'
+$ tail -f postgresql-<date_and_time>.log
+```
+
+#### webMethods Shutdown
+
+Shutting down the integration server has two options, one from the administrator application and another from a terminal. Remember on Windows there is is no Integration Server service in Task Manager.
+
+##### Administrator Application
+
+   1. As desired, in a terminal, go to the logs directory and tail the server.log file to observe the shutdown.
+
+      ```bash
+      $ cd <service_designer_home>/IntegrationServer/logs
+      $ tail -f server.log
+      ```
+
+   2. Select the Server control icon in the upper-righthand corner of the Administrator application, then select `Shut down or restart`.
+
+   3. In the Shut down or restart table, select any of them, for example, select `Immediately`, then select `Shut Down`. For our use case, there should be no other running services since this is the only integration.
+
+   4. Confirm the action by selecting `OK`. The ui should confirm the restart with a `Shutdown is in progress.` in the light blue banner above the table.
+
+##### Terminal or Command Line
+
+```bash
+$ cd <service_designer_home>/IntegrationServer/bin
+# shut down the server
+$ <service_designer_home>/IntegrationServer/bin/shutdown.sh
+```
+
+Monitor the integration server log file as desired.
+
 ## Project Structure
 
 ```

--- a/z_non-python_resources/database/about_database.md
+++ b/z_non-python_resources/database/about_database.md
@@ -8,6 +8,22 @@ This project uses PostgreSQL as its host database server. That is, we set up the
 
 We can't provide many recommendations about installing PostgreSQL since our experience is limited to running a network of older MacOS systems, using a MacOS-only version of PostgreSQL from eggerapps.at. Ours is version 14, way behind the latest version available, but more than enough for our simple database. Our database host is one of those older Macintosh systems running that server build with another system using their gui client, Postico.
 
+### Starting PostgreSQL
+
+Windows probably provides a Task Manager solution for starting and stopping PostgreSQL and Linux distributions running the database server probably also offer easier methods. We'll provide a command-line sequence so one at least has a startup example here.
+
+```bash
+$ cd /<postgresql_installation_directory>
+# start the server using pg_ctl
+$ /<postgresql_installation_directory>/bin/pg_ctl -D <data_directory> start
+# for example
+$ /Applications/Postgres.app/Contents/Versions/latest/bin/pg_ctl -D /Users/rrdoue/Library/ApplicationSupport/Postgres/var-14 start
+# check the server log file for information
+$ cd <data_directory>/log(s)
+# look for a line in the file below like '<date_and_time> [pid] LOG:  database system is ready to accept connections'
+$ tail -f postgresql-<date_and_time>.log
+	```
+
 ## Configuration
 
 No matter what os one is running, accessing the server may require some configuration changes to the pg_hba.conf file after installation. Configuration may be easier when running both the FastAPI instance and PostgreSQL server on the same host, since the default PostgreSQL installation includes lines for localhost access. The lines in the pg_hba.conf file that support local access include lines 89, 91, and 93. These lines allow access for any user that has a user id on the local system because of the trust entry in the METHOD column. However, those same local users must have access to the hr_sample database, and this depends on who installed it along with additional granted access.
@@ -49,7 +65,7 @@ Find a process that works for you and follow it.
 
 Reloading the configuration using the PostgreSQL utility called pg_ctl does not vary with operating system, but there are alternatives that may work better for you. For example, modern linux versions using systemd appear to offer alternatives using that. Running MacOS, I tend to execute the reload from a terminal command line, but not everyone is comfortable with the terminal. As an example, the full reload command takes the form of the following:
 
-`/<installation_directory>/bin/pg_ctl -D <data_directory> reload`
+`/<postgresql_installation_directory>/bin/pg_ctl -D <data_directory> reload`
 
 and for our v14 installation on MacOS, the command looks like the following:
 
@@ -81,15 +97,19 @@ The two files in [hr_sample_export](./database/hr_sample_export) are PostgreSQL 
 
 To import the database, (g)unzip the file, then run pg_restore with something like the following:
 
-`/<installation_directory>/bin/pg_restore -U <user_id> -h <server> -p <port> hr_sample_dump_w_create_wo_acls.sql`
+`/<postgresql_installation_directory>/bin/pg_restore -U <user_id> -h <server> -p <port> hr_sample_dump_w_create_wo_acls.sql`
 
 For our installation, we haven't run the command, but it should resemble something like the following:
 
 `/Applications/Postgres.app/Contents/Versions/latest/bin/pg_restore -U rrdoue -h localhost -p 5432 hr_sample_dump_w_create_wo_acls.sql`
 
+## Shutdown
+
+Please refer to the primary readme's [database shutdown section](../../README.md#database-shutdown) for PostgreSQL shutdown instructions.
+
 ## End
 
-Hopefully this was useful for those of us who don't work with database servers and their content often. If one completes the database section, all that is left is testing the connectivity with FastAPI as found in the [primary readme](../../README.md#usage). webMethods integration server and client [setup](../../z_non-python_resources/webmethods/about_webMethods.md) is the last section.
+Hopefully this was useful for those of us who don't work with database servers and their content often. If one completes the database section and testing the connectivity with FastAPI as found in the [primary readme](../../README.md#usage) is successful, all that is left is webMethods integration server and client [setup](../../z_non-python_resources/webmethods/about_webMethods.md) in the webMethods client section.
 
 Internet searches should provide numerous helpful suggestions about every topic in this file. Experiencing the most problems in this section with configuring access, I found the footnote references helpful.
 

--- a/z_non-python_resources/webmethods/about_webMethods.md
+++ b/z_non-python_resources/webmethods/about_webMethods.md
@@ -334,6 +334,10 @@ This problem will probably not occur during your testing, but an unexpected erro
 
 This error prevents the Status from changing from Suspended to Active on the scheduler page. If you would like to resolve this problem and retry the scheduled task, refer to this vendor [workaround](./about_globalvar_error.md). Resolving the error using the suggested fix does not appear to affect functionality or operation. The service runs as expected in Service Designer and in the Administrator ui. The problem only occurs when running the service as a scheduled task.
 
+## Shutdown
+
+Please refer to the primary readme's [integration server shutdown section](../../README.md#webmethods-shutdown) for webMethods shutdown instructions.
+
 ## End
 
 If you've gotten this far, congratulations on staying with the project! There's more in this project than I expected, or documentation is just more time-consuming.


### PR DESCRIPTION
These changes resolve the lack of shutdown instructions in the readme documentation. There is a summary section in the README and the other readme files refer to that file for shutdown suggestions.